### PR TITLE
Alternative logging approach

### DIFF
--- a/samples/CarterSample/Startup.cs
+++ b/samples/CarterSample/Startup.cs
@@ -8,22 +8,14 @@ namespace CarterSample
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Logging;
 
     public class Startup
     {
-        private readonly ILoggerFactory loggerFactory;
-
-        public Startup(ILoggerFactory loggerFactory)
-        {
-            this.loggerFactory = loggerFactory;
-        }
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<IActorProvider, ActorProvider>();
-            
-            //If you want to log what Carter finds you need to pass in a ILoggerFactory as ASP.Net Core does not offer a clean way to log extensions to IServiceCollection
-            services.AddCarter(this.loggerFactory);
+
+            services.AddCarter(enableDiagnostics: true);
         }
 
         public void Configure(IApplicationBuilder app, IConfiguration config)

--- a/samples/CarterSample/appsettings.json
+++ b/samples/CarterSample/appsettings.json
@@ -1,3 +1,8 @@
 ﻿{
-  "connectionString" :"mydb"
+  "connectionString": "mydb",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Trace"
+    }
+  }
 }

--- a/src/CarterDiagnostics.cs
+++ b/src/CarterDiagnostics.cs
@@ -1,0 +1,49 @@
+namespace Carter
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Extensions.Logging;
+
+    public class CarterDiagnostics
+    {
+        private List<Type> validators = new List<Type>();
+        private List<Type> modules = new List<Type>();
+        private List<Type> statusCodeHandlers = new List<Type>();
+        private List<Type> responseNegotiators = new List<Type>();
+
+        public void AddValidator(Type validatorType)
+            => validators.Add(validatorType);
+
+        public void AddModule(Type moduleType)
+            => modules.Add(moduleType);
+
+        public void AddStatusCodeHandler(Type handlerType)
+            => statusCodeHandlers.Add(handlerType);
+
+        public void AddResponseNegotiator(Type responseNegotiatorType)
+            => responseNegotiators.Add(responseNegotiatorType);
+
+        public void LogDiscoveredModules(ILogger logger)
+        {
+            foreach (var validator in validators)
+            {
+                logger.LogTrace("Found validator {ValidatorName}", validator.Name);
+            }
+
+            foreach (var module in modules)
+            {
+                logger.LogTrace("Found module {ModuleName}", module.FullName);
+            }
+
+            foreach (var sch in statusCodeHandlers)
+            {
+                logger.LogTrace("Found status code handler {StatusCodeHandlerName}", sch.FullName);
+            }
+
+            foreach (var negotiatator in responseNegotiators)
+            {
+                logger.LogTrace("Found response negotiator {ResponseNegotiatorName}", negotiatator.FullName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a follow-up to #87, with an alternative attempt to solve this so that people don’t have to pass an actual logger to it. This basically delays the logging to the `UseBotwin()` call and stores the results in a diagnostics object.

Another alternative would have been to resolve the types once at the beginning of `UseBotwin`, that way we could avoid that temporary object but we also would have to create every object once for nothing (as there’s unfortunately no way to see what’s registered with a service provider except resolving it).

Of course, the third alternative would be to change how Botwin is resolving the modules, similar to how MVC resolves controllers when they are not registered through DI. But that would have been a bit more complicated.