### PR TITLE
Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,9 @@ build_script:
 test_script:
   - cmd: dotnet test test\Carter.Tests\Carter.Tests.csproj
 
+nuget:
+  disable_publish_on_pr: true
+  
 artifacts:
   - path: '**\*.nupkg'
     name: packages
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: ubuntu
+
 version: 3.6.0-{build}
 
 branches:
@@ -15,11 +17,10 @@ dotnet_csproj:
   file_version: '{version}'
   informational_version: '{version}'
 
-build_script:
-  - cmd: dotnet pack src\Carter.csproj -c Release -o nupkgs
+configuration: Release
 
-test_script:
-  - cmd: dotnet test test\Carter.Tests\Carter.Tests.csproj
+build:
+  verbosity: minimal
 
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+version: 3.6.0-{build}
+
+branches:
+  only:
+    - master
+
+max_jobs: 1
+
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  version: '{version}'
+  package_version: '{version}'
+  assembly_version: '{version}'
+  file_version: '{version}'
+  informational_version: '{version}'
+
+build_script:
+  - cmd: dotnet pack src\Carter.csproj -c Release -o nupkgs
+
+test_script:
+  - cmd: dotnet test test\Carter.Tests\Carter.Tests.csproj
+
+artifacts:
+  - path: '**\*.nupkg'
+    name: packages
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.6.0-{build}
+version: 3.6.0.{build}
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.6.0.{build}
+version: 3.6.0-{build}
 
 branches:
   only:
@@ -10,6 +10,7 @@ dotnet_csproj:
   patch: true
   file: '**\*.csproj'
   version: '{version}'
+  version_prefix: '{version}'
   package_version: '{version}'
   assembly_version: '{version}'
   file_version: '{version}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ dotnet_csproj:
   patch: true
   file: '**\*.csproj'
   version: '{version}'
-  version_prefix: '{version}'
   package_version: '{version}'
   assembly_version: '{version}'
   file_version: '{version}'

--- a/src/Carter.csproj
+++ b/src/Carter.csproj
@@ -10,6 +10,7 @@
     <PackageLicenseUrl>https://github.com/CarterCommunity/Carter/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>https://github.com/CarterCommunity/Media/raw/master/carterlogo.png</PackageIconUrl>
     <LangVersion>latest</LangVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="7.2.0" />

--- a/src/Carter.csproj
+++ b/src/Carter.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>3.6.0</Version>
     <VersionPrefix>3.6.0</VersionPrefix>
     <Authors>Jonathan Channon</Authors>
     <Description>Carter is a library that allows Nancy-esque routing for use with ASP.Net Core.</Description>


### PR DESCRIPTION
Added .appveyor configuration to run `dotnet test` and `dotnet pack` on each commit to `master`.

The resulting nuget package will be available on the Appveyor project feed.

I have alternative config for Appveyor Linux beta, if that's more desirable.

I've done nothing to resolve the hard-coding of the base version number within the .appveyor config.

