### PR TITLE
Add ModuleType to HttpContext Items

### DIFF
--- a/src/CarterExtensions.cs
+++ b/src/CarterExtensions.cs
@@ -59,6 +59,8 @@ namespace Carter
                 var module = ctx.RequestServices.GetRequiredService(moduleType) as CarterModule;
                 var loggerFactory = ctx.RequestServices.GetService<ILoggerFactory>();
                 var logger = loggerFactory.CreateLogger(moduleType);
+                
+                ctx.Request.HttpContext.Items.Add("ModuleType", module.GetType());
 
                 if (!module.Routes.TryGetValue((ctx.Request.Method, path), out var routeHandler))
                 {


### PR DESCRIPTION
As the module type is not available in the HTML negotiator, I am adding the type to the HttpContext Items collection.