### PR TITLE
Add optional DependencyContextAssemblyCatalog in AddCarter

### DIFF
--- a/src/CarterExtensions.cs
+++ b/src/CarterExtensions.cs
@@ -162,9 +162,10 @@ namespace Carter
         /// Adds Carter to the specified <see cref="IServiceCollection"/>.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/> to add Carter to.</param>
-        public static void AddCarter(this IServiceCollection services)
+        /// <param name="assemblyCatalog">Optional <see cref="DependencyContextAssemblyCatalog"/> containing assemblies to add to the services collection. If not provided, the default catalog of assemblies is added, which includes Assembly.GetEntryAssembly.</param>
+        public static void AddCarter(this IServiceCollection services, DependencyContextAssemblyCatalog assemblyCatalog = null)
         {
-            var assemblyCatalog = new DependencyContextAssemblyCatalog();
+            assemblyCatalog = assemblyCatalog ?? new DependencyContextAssemblyCatalog();
 
             var assemblies = assemblyCatalog.GetAssemblies();
 


### PR DESCRIPTION
TL;DR assembly scanning does not work in all cases as one might expect.
E.g. entry assembly is not the one with carter modules when running tests with
```
dotnet restore
dotnet publish -c Release
dotnet packages/build/xunit.runner.console/tools/netcoreapp2.0/xunit.console.dll tests/MyTests/bin/Release/netcoreapp2.1/publish/MyTests.dll
```
No carter modules would be found then and it returns 404 on everything.

1. This is not breaking the API or current behavior in any way.
2. Otherwise a patch in AddCarter is needed in practically all projects which run tests with carter modules.

In practice same as #88 but rebased on current master.

I know there is work going on adding bootstrapper #122 but that seems won't be merged any time soon. This is a small patch for now.