### PR TITLE
Adds support for user-supplied openapi examples

### DIFF
--- a/samples/CarterSample/Features/Actors/OpenApi/GetActors.cs
+++ b/samples/CarterSample/Features/Actors/OpenApi/GetActors.cs
@@ -21,7 +21,7 @@ namespace CarterSample.Features.Actors.OpenApi
 
         public override string OperationId { get; } = "Actors_GetActors";
 
-        public override string SecuritySchema { get; set; } = "ApiKey";
+        public override string SecuritySchema { get; } = "ApiKey";
 
         public override QueryStringParameter[] QueryStringParameter { get; } =
         {

--- a/src/OpenApi/CarterOpenApi.cs
+++ b/src/OpenApi/CarterOpenApi.cs
@@ -4,8 +4,6 @@ namespace Carter.OpenApi
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
-    using System.Text;
     using System.Threading.Tasks;
     using Carter.Request;
     using FluentValidation.Validators;
@@ -147,6 +145,26 @@ namespace Carter.OpenApi
                     return OperationType.Get;
             }
         }
+        
+        private static void CreateOpenApiQueryStringParameters(OpenApiOperation operation, QueryStringParameter[] queryStringParameters)
+        {
+            if (queryStringParameters == null || !queryStringParameters.Any())
+            {
+                return;
+            }
+
+            foreach (var queryStringParameter in queryStringParameters)
+            {
+                operation.Parameters.Add(new OpenApiParameter
+                {
+                    In = ParameterLocation.Query,
+                    Required = queryStringParameter.Required,
+                    Name = queryStringParameter.Name,
+                    Description = queryStringParameter.Description,
+                    Schema = new OpenApiSchema { Type = GetOpenApiTypeMapping(queryStringParameter.Type.Name.ToLower()) }
+                });
+            }
+        }
 
         private static void CreateOpenApiRouteConstraints(RouteTemplate template, OpenApiOperation operation)
         {
@@ -245,6 +263,10 @@ namespace Carter.OpenApi
 
                     operation.Responses.Add(valueStatusCode.Code.ToString(), openApiResponse);
                 }
+            }
+            else
+            {
+                operation.Responses.Add("200", new OpenApiResponse { Description = string.Empty });
             }
         }
 

--- a/src/OpenApi/CarterOpenApi.cs
+++ b/src/OpenApi/CarterOpenApi.cs
@@ -531,7 +531,7 @@ namespace Carter.OpenApi
                 var arrayElementType = objectType.GetElementType() ?? GetEnumerableType(objectType);
 
                 var arrayElements = useDefaults
-                    ? (IEnumerable)Activator.CreateInstance(objectType)
+                    ? (IEnumerable)new List<object>()
                     : (IEnumerable)exampleValue;
 
                 var arrayExample = new OpenApiArray();

--- a/src/OpenApi/RouteMetaData.cs
+++ b/src/OpenApi/RouteMetaData.cs
@@ -5,8 +5,25 @@ namespace Carter.OpenApi
     /// <summary>
     /// A class to supply OpenApi data
     /// </summary>
-    public abstract class RouteMetaData
+    public  class RouteMetaData
     {
+        public RouteMetaData(
+            string description = null, 
+            string tag = null, 
+            Type request = null, 
+            RouteMetaDataResponse[] responses = null, 
+            string operationId = null, 
+            string securitySchema = null, 
+            QueryStringParameter[] queryStringParameter = null)
+        {
+            this.Description = description;
+            this.Tag = tag;
+            this.Request = request;
+            this.Responses = responses;
+            this.OperationId = operationId;
+            this.SecuritySchema = securitySchema;
+            this.QueryStringParameter = queryStringParameter;
+        }
         /// <summary>
         /// A description about the route
         /// </summary>
@@ -21,6 +38,8 @@ namespace Carter.OpenApi
         /// The <see cref="Type"/> of the request body
         /// </summary>
         public virtual Type Request { get; }
+        
+        public virtual object RequestExample { get; }
 
         /// <summary>
         /// An array of possible <see cref="RouteMetaDataResponse"/>s that can be returned from the route
@@ -35,7 +54,7 @@ namespace Carter.OpenApi
         /// <summary>
         /// The name of a security schema used in the API
         /// </summary>
-        public virtual string SecuritySchema { get; set; }
+        public virtual string SecuritySchema { get; }
         
         /// <summary>
         /// An array of possible <see cref="QueryStringParameter"/>s that a route may use

--- a/src/OpenApi/RouteMetaDataResponse.cs
+++ b/src/OpenApi/RouteMetaDataResponse.cs
@@ -21,5 +21,7 @@ namespace Carter.OpenApi
         /// The <see cref="Type"/> of response body
         /// </summary>
         public Type Response { get; set; }
+        
+        public object ResponseExample { get; set; }
     }
 }

--- a/test/Carter.Tests/OpenApiTests.cs
+++ b/test/Carter.Tests/OpenApiTests.cs
@@ -1,0 +1,39 @@
+namespace Carter.Tests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Carter.OpenApi;
+    using Microsoft.AspNetCore.Http;
+    using Xunit;
+
+    public class OpenApiTests
+    {
+        private class ExampleResponse
+        {
+            public IEnumerable<string> Dogs { get; set; } = new[] { "Labrador", "Golden Retriever", "Alsation" };
+        }
+
+        [Fact]
+        public async Task Get_OpenAPI_Response()
+        {
+            var openApiDelegate = OpenApi.CarterOpenApi.BuildOpenApiResponse(
+                new CarterOptions(openApiOptions: new OpenApiOptions("OpenAPI Docs", new[] { "http://localhost" }, new Dictionary<string, OpenApiSecurity>())),
+                new Dictionary<(string verb, string path), RouteMetaData>()
+                {
+                    { ("GET", "/foo"), new RouteMetaData(responses: new[] { new RouteMetaDataResponse() }) }
+                }
+            );
+
+            using (var body = new MemoryStream())
+            {
+                var ctx = new DefaultHttpContext();
+                ctx.Response.Body = body;
+                await openApiDelegate.Invoke(ctx);
+                var responseBody = Encoding.UTF8.GetString(body.ToArray());
+                Assert.Contains("Docs", responseBody);
+            }
+        }
+    }
+}


### PR DESCRIPTION
(As discussed in slack)

Users can supply an example instance on `RouteMetaData` and
`RouteMetaDataResponse`. If supplied, the values on these objects will
be used to populate examples in the OpenApi schemas. If no example
objects are supplied, then this PR still improves example output,
displaying correctly typed values rather than deciding everything is a
string, and correctly handling nested object structures rather than only
including top-level properties in examples.