### PR TITLE
Issue #194 Invalid cast from 'System.String' to 'System.Guid'

### DIFF
--- a/src/ModelBinding/BindExtensions.cs
+++ b/src/ModelBinding/BindExtensions.cs
@@ -62,6 +62,17 @@ namespace Carter.ModelBinding
                         }
                         return val.Value.Select(y => Convert.ChangeType(y, colType));
                     }
+
+                    // Convert.ChangeType (below) chokes on Guids, so doing it here instead.
+                    if (propertyType == typeof(Guid) || propertyType == typeof(Guid?))
+                    {
+                        if (Guid.TryParse(val.Value[0], out Guid result))
+                        {
+                            return result;
+                        }
+                        return Guid.Empty;
+                    }
+
                     //int, double etc
                     return Convert.ChangeType(val.Value[0], propertyType);
                 }));

--- a/test/Carter.Tests/Modelbinding/BindTests.cs
+++ b/test/Carter.Tests/Modelbinding/BindTests.cs
@@ -55,7 +55,8 @@ namespace Carter.Tests.Modelbinding
                         new KeyValuePair<string, string>("MyIntArrayProperty", "3"),
                         new KeyValuePair<string, string>("MyIntListProperty", "1"),
                         new KeyValuePair<string, string>("MyIntListProperty", "2"),
-                        new KeyValuePair<string, string>("MyIntListProperty", "3")
+                        new KeyValuePair<string, string>("MyIntListProperty", "3"),
+                        new KeyValuePair<string, string>("MyGuidProperty", "E3D2E063-BDC6-426E-A27B-0AAFB5D17AE5")
                     }));
 
             //When
@@ -69,6 +70,7 @@ namespace Carter.Tests.Modelbinding
             Assert.Equal(new[] { "1", "2", "3" }, model.MyArrayProperty);
             Assert.Equal(Enumerable.Range(1, 3), model.MyIntArrayProperty);
             Assert.Equal(Enumerable.Range(1, 3), model.MyIntListProperty);
+            Assert.Equal(Guid.Parse("E3D2E063-BDC6-426E-A27B-0AAFB5D17AE5"), model.MyGuidProperty);
         }
 
         [Fact]

--- a/test/Carter.Tests/Modelbinding/TestModel.cs
+++ b/test/Carter.Tests/Modelbinding/TestModel.cs
@@ -1,5 +1,6 @@
 namespace Carter.Tests.Modelbinding
 {
+    using System;
     using System.Collections.Generic;
 
     public class TestModel
@@ -15,5 +16,7 @@ namespace Carter.Tests.Modelbinding
         public IEnumerable<int> MyIntArrayProperty { get; set; }
 
         public IEnumerable<int> MyIntListProperty { get; set; }
+
+        public Guid MyGuidProperty { get; set; }
     }
 }


### PR DESCRIPTION
Fix "Invalid cast from 'System.String' to 'System.Guid'." issue. Happens when submitting a PUT request that has Guids as part of its body.