### PR TITLE
Introduced TryValidate<T>() extension method

### DIFF
--- a/src/Carter/ModelBinding/ValidationExtensions.cs
+++ b/src/Carter/ModelBinding/ValidationExtensions.cs
@@ -26,6 +26,29 @@ namespace Carter.ModelBinding
         }
 
         /// <summary>
+        /// Performs validation on the specified <paramref name="model"/> instance
+        /// </summary>
+        /// <typeparam name="T">The type of the <paramref name="model"/> that is being validated</typeparam>
+        /// <param name="request">Current <see cref="HttpRequest"/></param>
+        /// <param name="model">The model instance that is being validated</param>
+        /// <param name="result"><see cref="ValidationResult"/></param>
+        /// <returns>true if there's a validator associated with the <paramref name="model"/></returns>
+        public static bool TryValidate<T>(this HttpRequest request, T model, out ValidationResult result)
+        {
+            var validatorLocator = request.HttpContext.RequestServices.GetService<IValidatorLocator>();
+            var validator = validatorLocator?.GetValidator<T>();
+
+            if (validator == null)
+            {
+                result = null;
+                return false;
+            }
+
+            result = validator.Validate(model);
+            return true;
+        }
+
+        /// <summary>
         /// Retrieve formatted validation errors
         /// </summary>
         /// <param name="result"><see cref="ValidationResult"/></param>


### PR DESCRIPTION
...for `HttpRequest` which accompanies `Validate<T>()`, but is more flexible, because it allows to explicitly handle the case when the model's validator is missing.