### PR TITLE
Tweak MinVer

### DIFF
--- a/src/Carter/Carter.csproj
+++ b/src/Carter/Carter.csproj
@@ -11,6 +11,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+        <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
     </PropertyGroup>
     <ItemGroup>
         <None Include="..\..\media\carterlogo.png" Pack="true" PackagePath="\" />
@@ -23,7 +24,9 @@
         <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.0" />
         <PackageReference Include="Microsoft.OpenApi" Version="1.1.4" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="all" />
-        <PackageReference Include="MinVer" Version="2.0.0" />
+        <PackageReference Include="MinVer" Version="2.0.0">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Marks MinVer as a  which makes sure it doesn't show up in
the final build as a dependency. Also, only runs MinVer on
builds.