### PR TITLE
Add Enabled To OpenAPI Options

### DIFF
--- a/src/Carter/CarterExtensions.cs
+++ b/src/Carter/CarterExtensions.cs
@@ -72,7 +72,10 @@ namespace Carter
             }
 
             var options = builder.ServiceProvider.GetRequiredService<IOptions<CarterOptions>>().Value;
-            builders.Add(builder.MapGet("openapi", BuildOpenApiResponse(options, routeMetaData)));
+            if (options.OpenApi.Enabled)
+            {
+                builders.Add(builder.MapGet("openapi", BuildOpenApiResponse(options, routeMetaData)));
+            }
 
             return new CompositeConventionBuilder(builders);
         }

--- a/src/Carter/CarterOptions.cs
+++ b/src/Carter/CarterOptions.cs
@@ -46,6 +46,11 @@ namespace Carter
         /// The global security definitions that apply to the api that OpenApi describes
         /// </summary>
         public IEnumerable<string> GlobalSecurityDefinitions { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// Determines if OpenAPI should be mapped and enabled. True by default.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
     }
 
     /// <summary>


### PR DESCRIPTION
Allows you to disable the GET endpoint for OpenAPI
for thos folks who don't want it as part of their
Carter instance.

 #229

Should be backward compatible safe.