### PR TITLE
Add Newtonsoft Json response negotiator

### DIFF
--- a/src/Carter/CarterExtensions.cs
+++ b/src/Carter/CarterExtensions.cs
@@ -7,6 +7,7 @@ namespace Carter
     using System.Threading.Tasks;
     using Carter.ModelBinding;
     using Carter.OpenApi;
+    using Carter.Response;
     using FluentValidation;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Http;
@@ -242,7 +243,8 @@ namespace Carter
                         !t.IsAbstract &&
                         typeof(IResponseNegotiator).IsAssignableFrom(t) &&
                         t != typeof(IResponseNegotiator) &&
-                        t != typeof(DefaultJsonResponseNegotiator)
+                        t != typeof(DefaultJsonResponseNegotiator) &&
+                        t != typeof(NewtonsoftJsonResponseNegotiator)
                     ));
 
                 carterConfigurator.ResponseNegotiatorTypes.AddRange(responseNegotiators);

--- a/src/Carter/Response/DefaultJsonResponseNegotiator.cs
+++ b/src/Carter/Response/DefaultJsonResponseNegotiator.cs
@@ -1,4 +1,4 @@
-﻿namespace Carter
+﻿namespace Carter.Response
 {
     using System;
     using System.Text.Json;

--- a/src/Carter/Response/NewtonsoftJsonResponseNegotiator.cs
+++ b/src/Carter/Response/NewtonsoftJsonResponseNegotiator.cs
@@ -1,0 +1,33 @@
+namespace Carter.Response
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Net.Http.Headers;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+
+    public class NewtonsoftJsonResponseNegotiator : IResponseNegotiator
+    {
+        private readonly JsonSerializerSettings jsonSettings;
+
+        public NewtonsoftJsonResponseNegotiator()
+        {
+            var contractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            };
+            this.jsonSettings = new JsonSerializerSettings { ContractResolver = contractResolver, NullValueHandling = NullValueHandling.Ignore };
+        }
+        public bool CanHandle(MediaTypeHeaderValue accept)
+        {
+            return accept.MediaType.ToString().IndexOf("json", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+        public Task Handle(HttpRequest req, HttpResponse res, object model, CancellationToken cancellationToken)
+        {
+            res.ContentType = "application/json; charset=utf-8";
+            return res.WriteAsync(JsonConvert.SerializeObject(model, this.jsonSettings), cancellationToken);
+        }
+    }
+}

--- a/test/Carter.Tests/ContentNegotiation/Newtonsoft/NewtonsoftJsonResponseNegotiatorModule.cs
+++ b/test/Carter.Tests/ContentNegotiation/Newtonsoft/NewtonsoftJsonResponseNegotiatorModule.cs
@@ -1,0 +1,12 @@
+namespace Carter.Tests.ContentNegotiation.Newtonsoft
+{
+    using Carter.Response;
+
+    public class NewtonsoftJsonResponseNegotiatorModule : CarterModule
+    {
+        public NewtonsoftJsonResponseNegotiatorModule()
+        {
+            this.Get("/negotiate", (req, res) => res.Negotiate(new { FirstName = "Jim" }));
+        }
+    }
+}

--- a/test/Carter.Tests/ContentNegotiation/Newtonsoft/NewtonsoftJsonResponseNegotiatorTests.cs
+++ b/test/Carter.Tests/ContentNegotiation/Newtonsoft/NewtonsoftJsonResponseNegotiatorTests.cs
@@ -1,0 +1,94 @@
+namespace Carter.Tests.ContentNegotiation.Newtonsoft
+{
+    using System;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Carter.Response;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.TestHost;
+    using Xunit;
+    using MediaTypeHeaderValue = Microsoft.Net.Http.Headers.MediaTypeHeaderValue;
+
+    public class NewtonsoftJsonResponseNegotiatorTests
+    {
+        public NewtonsoftJsonResponseNegotiatorTests()
+        {
+            this.server = new TestServer(
+                new WebHostBuilder()
+                    .ConfigureServices(x =>
+                    {
+                        x.AddCarter(configurator: c =>
+                        {
+                            c.WithModule<NegotiatorModule>();
+                            c.WithResponseNegotiator<TestJsonResponseNegotiator>();
+                            c.WithResponseNegotiator<NewtonsoftJsonResponseNegotiator>();
+                        });
+                    })
+                    .Configure(x =>
+                    {
+                        x.UseRouting();
+                        x.UseEndpoints(builder => builder.MapCarter());
+                    })
+            );
+            this.httpClient = this.server.CreateClient();
+        }
+
+        private readonly TestServer server;
+
+        private readonly HttpClient httpClient;
+
+        [Theory]
+        [InlineData("not/known")]
+        [InlineData("utt$r-rubbish-9")]
+        public async Task Should_fallback_to_json(string accept)
+        {
+            this.httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Accept", accept);
+            var response = await this.httpClient.GetAsync("/negotiate");
+            Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType.ToString());
+        }
+
+        [Fact]
+        public async Task Should_camelCase_json()
+        {
+            this.httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            var response = await this.httpClient.GetAsync("/negotiate");
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.Equal("{\"firstName\":\"Jim\"}", body);
+        }
+
+        [Fact]
+        public async Task Should_fallback_to_json_even_if_no_accept_header()
+        {
+            var response = await this.httpClient.GetAsync("/negotiate");
+            Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType.ToString());
+        }
+
+        [Fact]
+        public async Task Should_pick_default_json_processor_last()
+        {
+            this.httpClient.DefaultRequestHeaders.Accept.Add(
+                new MediaTypeWithQualityHeaderValue("application/vnd.badger+json"));
+            var response = await this.httpClient.GetAsync("/negotiate");
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.Equal("Non default json Response", body);
+        }
+    }
+
+    internal class TestJsonResponseNegotiator : IResponseNegotiator
+    {
+        public bool CanHandle(MediaTypeHeaderValue accept) => accept
+            .MediaType.ToString()
+            .IndexOf("application/vnd.badger+json",
+                StringComparison.OrdinalIgnoreCase) >= 0;
+
+        public async Task Handle(HttpRequest req, HttpResponse res, object model,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await res.WriteAsync("Non default json Response", cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
- Add Newtonsoft Json response negotiator and unit tests
- Move `DefaultJsonResponseNegotiator` under `Carter.Response` namespace.