### PR TITLE
Revert "Introduced TryValidate<T>() extension method for HttpRequest …

### DIFF
--- a/src/Carter/ModelBinding/ValidationExtensions.cs
+++ b/src/Carter/ModelBinding/ValidationExtensions.cs
@@ -27,29 +27,6 @@ namespace Carter.ModelBinding
         }
 
         /// <summary>
-        /// Performs validation on the specified <paramref name="model"/> instance
-        /// </summary>
-        /// <typeparam name="T">The type of the <paramref name="model"/> that is being validated</typeparam>
-        /// <param name="request">Current <see cref="HttpRequest"/></param>
-        /// <param name="model">The model instance that is being validated</param>
-        /// <param name="result"><see cref="ValidationResult"/></param>
-        /// <returns>true if there's a validator associated with the <paramref name="model"/></returns>
-        public static bool TryValidate<T>(this HttpRequest request, T model, out ValidationResult result)
-        {
-            var validatorLocator = request.HttpContext.RequestServices.GetService<IValidatorLocator>();
-            var validator = validatorLocator?.GetValidator<T>();
-
-            if (validator == null)
-            {
-                result = null;
-                return false;
-            }
-
-            result = validator.Validate(model);
-            return true;
-        }
-
-        /// <summary>
         /// Retrieve formatted validation errors
         /// </summary>
         /// <param name="result"><see cref="ValidationResult"/></param>


### PR DESCRIPTION
…which accompanies Validate<T>(), but is more flexible, because it allows to explicitly handle the case when model validator is missing. (#230)"

This reverts commit 6e4024b06504c605a77b4d09aaa15fdfa6ede88c.