### PR TITLE
Corrections to address openapi generation failure for nullable types

### DIFF
--- a/samples/CarterSample/Features/Actors/ActorsModule.cs
+++ b/samples/CarterSample/Features/Actors/ActorsModule.cs
@@ -77,6 +77,8 @@ namespace CarterSample.Features.Actors
             this.Get<SampleMetaData>("/actors/sample", (request, response) => Task.CompletedTask);
 
             this.Post<NoValidatorMetaData>("/actors/sample", (request, response) => Task.CompletedTask);
+
+            this.Get<GetSimpleNullables>("/nullable", (request, response) => Task.CompletedTask);
         }
     }
 }

--- a/samples/CarterSample/Features/Actors/OpenApi/GetSimpleNullables.cs
+++ b/samples/CarterSample/Features/Actors/OpenApi/GetSimpleNullables.cs
@@ -1,0 +1,24 @@
+namespace CarterSample.Features.Actors.OpenApi
+{
+    using Carter.OpenApi;
+    using System.Collections.Generic;
+
+    public class GetSimpleNullables : RouteMetaData
+    {
+        public override string Description { get; } = "Gets a SimpleNullable object";
+
+        public override RouteMetaDataResponse[] Responses { get; } =
+        {
+            new RouteMetaDataResponse
+            {
+                Code = 200,
+                Description = $"A list of {nameof(SimpleNullable)}s",
+                Response = typeof(List<SimpleNullable>)
+            }
+        };
+
+        public override string Tag { get; } = "SimpleNullable";
+
+        public override string OperationId { get; } = "SimpleNullable";
+    }
+}

--- a/samples/CarterSample/Features/Actors/SimpleNullable.cs
+++ b/samples/CarterSample/Features/Actors/SimpleNullable.cs
@@ -1,0 +1,12 @@
+namespace CarterSample.Features.Actors
+{
+    public class SimpleNullable
+    {
+        public ulong Id { get; set; }
+        public ulong? NullableId { get; set; }
+        public bool? NullableBool { get; set; }
+        public int? NullableInt { get; set; }
+        public double? NullableDouble { get; set; }
+        public float? NullableFloat { get; set; }
+    }
+}

--- a/src/Carter/OpenApi/CarterOpenApi.cs
+++ b/src/Carter/OpenApi/CarterOpenApi.cs
@@ -110,10 +110,17 @@ namespace Carter.OpenApi
                 ElementType = type
             };
 
-            // Prevent the navigation from including the properties of a string and
-            // simple nullable types
-            if (fullName == "System.String" || schemaElement.IsSimpleNullable())
+            // Prevent the navigation from including the properties of a string.
+            if (fullName == "System.String")
             {
+                navigation.Add(fullName, schemaElement);
+                return;
+            }
+
+            // Prevent the navigation from including the properties of a simple nullable type.
+            if (schemaElement.IsSimpleNullable())
+            {
+                schemaElement.ShortName = "NullableOf" + Nullable.GetUnderlyingType(schemaElement.ElementType).Name;
                 navigation.Add(fullName, schemaElement);
                 return;
             }

--- a/test/Carter.Samples.Tests/OpenAPITests.Should_return_Carter_approved_OpenAPI_json.approved.txt
+++ b/test/Carter.Samples.Tests/OpenAPITests.Should_return_Carter_approved_OpenAPI_json.approved.txt
@@ -228,6 +228,30 @@
           }
         }
       }
+    },
+    "/nullable": {
+      "get": {
+        "tags": [
+          "SimpleNullable"
+        ],
+        "description": "Gets a SimpleNullable object",
+        "operationId": "SimpleNullable",
+        "responses": {
+          "200": {
+            "description": "A list of SimpleNullables",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SimpleNullable"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -297,6 +321,34 @@
             "items": {
               "$ref": "#/components/schemas/Foo"
             }
+          }
+        }
+      },
+      "SimpleNullable": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "nullableId": {
+            "type": "integer",
+            "nullable": true
+          },
+          "nullableBool": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "nullableInt": {
+            "type": "integer",
+            "nullable": true
+          },
+          "nullableDouble": {
+            "type": "number",
+            "nullable": true
+          },
+          "nullableFloat": {
+            "type": "number",
+            "nullable": true
           }
         }
       }


### PR DESCRIPTION
These fixes are needed to address a bug that affects some objects that contain simple nullable types, such as "int?".