### PR TITLE
Change module scoped logger

### DIFF
--- a/src/Carter/CarterExtensions.cs
+++ b/src/Carter/CarterExtensions.cs
@@ -83,11 +83,6 @@ namespace Carter
         {
             return async ctx =>
             {
-                using var moduleScope = logger.BeginScope(new Dictionary<string, object>()
-                {
-                    ["ModuleType"] = moduleType.Name
-                });
-                
                 // Now in per-request scope
                 var module = ctx.RequestServices.GetRequiredService(moduleType) as CarterModule;
 
@@ -118,7 +113,8 @@ namespace Carter
                 if (shouldContinue)
                 {
                     // run the route handler
-                    logger.LogDebug("Executing module route handler for {Method} /{Path}", ctx.Request.Method, path);
+                    logger.LogDebug("Executing {ModuleType} route handler for {Method} {Path}", 
+                        moduleType.Namespace, ctx.Request.Method, path);
                     await routeHandler.handler(ctx);
 
                     // run after handler

--- a/src/Carter/CarterExtensions.cs
+++ b/src/Carter/CarterExtensions.cs
@@ -43,11 +43,10 @@ namespace Carter
             {
                 var statusCodeHandlers = scope.ServiceProvider.GetServices<IStatusCodeHandler>().ToList();
 
+                var carterLogger = loggerFactory.CreateLogger("Carter");
+
                 //Get all instances of CarterModule to fetch and register declared routes
-                foreach (var module in scope.ServiceProvider.GetServices<CarterModule>()) {
-                    
-                    var carterLogger = loggerFactory.CreateLogger("Carter");
-                    
+                foreach(var module in scope.ServiceProvider.GetServices<CarterModule>()) {
                     routeMetaData = routeMetaData.Concat(module.RouteMetaData).ToDictionary(x => x.Key, x => x.Value);
 
                     foreach (var route in module.Routes)

--- a/src/Carter/CarterExtensions.cs
+++ b/src/Carter/CarterExtensions.cs
@@ -83,9 +83,9 @@ namespace Carter
         {
             return async ctx =>
             {
-                using var moduleLogger = logger.BeginScope(new
+                using var moduleScope = logger.BeginScope(new Dictionary<string, object>()
                 {
-                    ModuleType = moduleType.Name
+                    ["ModuleType"] = moduleType.Name
                 });
                 
                 // Now in per-request scope

--- a/test/Carter.Tests/Carter.Tests.csproj
+++ b/test/Carter.Tests/Carter.Tests.csproj
@@ -8,4 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Carter\Carter.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
+  </ItemGroup>
 </Project>

--- a/test/Carter.Tests/Modules/CarterModuleTests.cs
+++ b/test/Carter.Tests/Modules/CarterModuleTests.cs
@@ -5,16 +5,25 @@
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.TestHost;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using Xunit;
+    using Xunit.Abstractions;
 
     public class CarterModuleTests
     {
-        public CarterModuleTests()
+        public CarterModuleTests(ITestOutputHelper outputHelper)
         {
             this.server = new TestServer(
                 new WebHostBuilder()
                     .ConfigureServices(x =>
                     {
+                        x.AddLogging(b =>
+                        {
+                            b.AddXUnit(outputHelper, x => x.IncludeScopes = true);
+                            b.SetMinimumLevel(LogLevel.Debug);
+                        });
+                        
                         x.AddCarter(configurator: c =>
                             c.WithModule<TestModule>()
                                 .WithModule<MultipleShortCircuitOnOff>()


### PR DESCRIPTION
This PR changes the logger used in the request lambda in `CarterExtensions` to use a category of `Carter` instead of the full name of the module type. The module type name is then added as a scope in the request handler.

This makes it possible to filter out the `Executing module route handler for` message filtering out `Carter` category instead of having to do it on each module type. It should generally be possible to filter out carter logs with the `Carter` category I think.

I've addded `MartinCostello.Logging.XUnit` which connects XUnit's `ITestOutputHelper` with ANC logging so the logs will show up in the test output, so it's easy to see what is being output. Currently only added it to the `CarterModuleTests`, not sure if we want/need this behaviour elsewhere. I think its useful.