### PR TITLE
Upgrade FluentValidation

### DIFF
--- a/samples/ValidatorOnlyProject/ValidatorOnlyProject.csproj
+++ b/samples/ValidatorOnlyProject/ValidatorOnlyProject.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="8.5.1" />
+    <PackageReference Include="FluentValidation" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Carter/Carter.csproj
+++ b/src/Carter/Carter.csproj
@@ -20,7 +20,7 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="8.5.1" />
+        <PackageReference Include="FluentValidation" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.0" />
         <PackageReference Include="Microsoft.OpenApi" Version="1.1.4" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="all" />

--- a/src/Carter/ModelBinding/ValidationExtensions.cs
+++ b/src/Carter/ModelBinding/ValidationExtensions.cs
@@ -3,6 +3,7 @@ namespace Carter.ModelBinding
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using FluentValidation;
     using FluentValidation.Results;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +24,7 @@ namespace Carter.ModelBinding
 
             return validator == null
                 ? throw new NullReferenceException("")//new ValidationResult(new[] { new ValidationFailure(typeof(T).Name, "No validator found") })
-                : validator.Validate(model);
+                : validator.Validate(new ValidationContext<T>(model));
         }
 
         /// <summary>


### PR DESCRIPTION
With FluentValidation 9, the non-generic `IValidator.Validate(model)` has been removed. An alternative already exists, which is `IValidator.Validate(ValidationContext)`, so the callsite has changed to use that instead.