### PR TITLE
Test failures

### DIFF
--- a/test/Carter.Tests/Modelbinding/BindTests.cs
+++ b/test/Carter.Tests/Modelbinding/BindTests.cs
@@ -56,7 +56,7 @@ namespace Carter.Tests.ModelBinding
                     {
                         new KeyValuePair<string, string>("myintproperty", "1"),
                         new KeyValuePair<string, string>("MyStringProperty", "hi there"),
-                        new KeyValuePair<string, string>("MyDoubleProperty", "2.3"),
+                        new KeyValuePair<string, string>("MyDoubleProperty", 2.3M.ToString()),
                         new KeyValuePair<string, string>("MyArrayProperty", "1"),
                         new KeyValuePair<string, string>("MyArrayProperty", "2"),
                         new KeyValuePair<string, string>("MyArrayProperty", "3"),
@@ -80,8 +80,8 @@ namespace Carter.Tests.ModelBinding
                         new KeyValuePair<string, string>("MyEmptyGuidProperty", ""),
                         new KeyValuePair<string, string>("MyEmptyNullableGuidProperty", ""),
                         new KeyValuePair<string, string>("MyEmptyNullableDateTimeProperty", ""),
-                        new KeyValuePair<string, string>("MyDecimalProperty", "1234.00"),
-                        new KeyValuePair<string, string>("MyFormattedDecimalProperty", "1,234.00")
+                        new KeyValuePair<string, string>("MyDecimalProperty", 1234M.ToString("0.##")),
+                        new KeyValuePair<string, string>("MyFormattedDecimalProperty", 1234.ToString("N2"))
                     }));
 
             //When

--- a/test/Carter.Tests/TestModule.cs
+++ b/test/Carter.Tests/TestModule.cs
@@ -1,6 +1,7 @@
 namespace Carter.Tests
 {
     using System;
+    using System.Globalization;
     using System.Linq;
     using Carter.Request;
     using Microsoft.AspNetCore.Http;
@@ -70,7 +71,7 @@ namespace Carter.Tests
             this.Get("/parameterized/{name:alpha}", ctx => ctx.Response.WriteAsync("echo " + ctx.GetRouteData().Values["name"]));
             this.Get("/parameterized/{id:int}", ctx => ctx.Response.WriteAsync("echo " + ctx.Request.RouteValues.As<int>("id")));
             this.Get("/parameterized/{id:guid}", ctx => ctx.Response.WriteAsync("echo " + ctx.Request.RouteValues.As<Guid>("id")));
-            this.Get("/parameterized/{id:datetime}", ctx => ctx.Response.WriteAsync("echo " + ctx.Request.RouteValues.As<DateTime>("id").ToString("dd/MM/yyyy hh:mm:ss")));
+            this.Get("/parameterized/{id:datetime}", ctx => ctx.Response.WriteAsync("echo " + ctx.Request.RouteValues.As<DateTime>("id").ToString("dd/MM/yyyy hh:mm:ss", CultureInfo.InvariantCulture)));
 
             this.Post("/", async ctx => { await ctx.Response.WriteAsync("Hello"); });
             this.Put("/", async ctx => { await ctx.Response.WriteAsync("Hello"); });


### PR DESCRIPTION
4 tests were failing due to assuming english formatting of dates and decimals. When run on systems with non-english regional settings, these tests would fail. I have corrected the tests to cater for different regional settings.