### PR TITLE
Added a new extension for ValidationResult

### DIFF
--- a/src/Carter/ModelBinding/ValidationExtensions.cs
+++ b/src/Carter/ModelBinding/ValidationExtensions.cs
@@ -1,12 +1,12 @@
 namespace Carter.ModelBinding
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using FluentValidation;
     using FluentValidation.Results;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.DependencyInjection;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
     public static class ValidationExtensions
     {
@@ -36,6 +36,19 @@ namespace Carter.ModelBinding
         {
             return result.Errors.Select(x => new ModelError { PropertyName = x.PropertyName, ErrorMessage = x.ErrorMessage });
         }
+
+        /// <summary>
+        /// Retrieve formatted validation errors for validation problem result
+        /// </summary>
+        /// <param name="result"></param>
+        /// <returns></returns>
+        public static Dictionary<string, string[]> GetValidationProblems(this ValidationResult result)
+        {
+            return result.Errors
+                .GroupBy(e => e.PropertyName, e => e.ErrorMessage)
+                .ToDictionary(failureGroup => failureGroup.Key, failureGroup => failureGroup.ToArray());
+        }
+
     }
 
     public class ModelError


### PR DESCRIPTION
New extension for `ValidationResult` called `GetValidationProblems`.

Example Usage:
```csharp
var result = request.Validate(command);

if (!result.IsValid)
{
     return Results.ValidationProblem(result.GetValidationProblems());
}
```

Response:
```json
{
  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
  "title": "One or more validation errors occurred.",
  "status": 400,
  "errors": {
    "Name": [
      "'Name' no debería estar vacío."
    ],
    "Description": [
      "'Description' no debería estar vacío."
    ],
    "Price": [
      "'Price' no debería estar vacío."
    ]
  }
}
```
