### PR TITLE
Publish the `CarterTemplate` package automatically

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "minver-cli": {
+      "version": "2.5.0",
+      "commands": [
+        "minver"
+      ]
+    }
+  }
+}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -51,8 +51,13 @@ jobs:
           path: '**/*.trx'
           reporter: dotnet-trx
 
-    # PR opened, push prelease Carter and template package to feedz
-    - if: github.event_name == 'pull_request'
+    # If we intend on publishing the CarterTemplate package, we need to
+    # replace the <ProjectReference /> element with a <PackageReference /> one
+    # and create the NuGet package
+    - if: >-
+        (github.event_name == 'pull_request')
+        ||
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/newtonsoft-'))
       name: Replace project reference with NuGet package reference in template project
       run: >-
         ./replace-project-reference-with-package-reference.ps1
@@ -60,20 +65,24 @@ jobs:
         -PackageVersion $env:MINVERVERSIONOVERRIDE
       shell: pwsh
 
-    - if: github.event_name == 'pull_request'
+    - if: >-
+        (github.event_name == 'pull_request')
+        ||
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/newtonsoft-'))
       name: Create Carter template NuGet package
       run: >-
         dotnet pack ./template/Template.csproj
         --configuration Release
         --nologo
 
+    # PR opened, push prelease Carter and CarterTemplate packages to feedz
     - if: github.event_name == 'pull_request'
-      name: Push prerelease Carter package to Feedz
+      name: Push prerelease Carter packages to Feedz
       run: ./push.sh carter feedz ${{ secrets.FEEDZ_KEY }}
 
-    # Main tag created, push release Carter package to NuGet
+    # Main tag created, push prelease Carter and CarterTemplate packages to NuGet
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/newtonsoft-')
-      name: Push release Carter package to NuGet
+      name: Push release Carter packages to NuGet
       run: ./push.sh carter nuget ${{ secrets.NUGET_KEY }}
 
     # Newtonsoft tag created, push release Newtonsoft package to NuGet

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -40,7 +40,7 @@ jobs:
         $patch = $minVerVersion.Split('.')[2].Split('-')[0].Split('+')[0]
 
         $pullRequestMinVerVersion = '{0}.{1}.{2}-pr.{3}.build.{4}' -f $major, $minor, $patch, '${{ github.event.number }}', $env:GITHUB_RUN_ID
-        Write-Output -Value ('Pull request MinVer version: {0}' -f $pullRequestMinVerVersion)
+        Write-Output -InputObject ('Pull request MinVer version: {0}' -f $pullRequestMinVerVersion)
 
         ('MINVERVERSIONOVERRIDE={0}' -f $pullRequestMinVerVersion) >> $env:GITHUB_ENV
       shell: pwsh

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         CARTER_VERSION=$(dotnet minver --verbosity error)
         echo "Computed version by MinVer: $CARTER_VERSION"
-        echo "MINVERVERSIONOVERRIDE=$CARTER_VERSION" >> GITHUB_ENV
+        echo "MINVERVERSIONOVERRIDE=$CARTER_VERSION" >> $GITHUB_ENV
     - name: Build Reason
       run: echo ${{github.ref}} and ${{github.event_name}}
     - name: Build with dotnet

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -22,10 +22,20 @@ jobs:
       with:
         dotnet-version: 7.*
         include-prerelease: true
+    - name: Restore .NET tools
+      run: dotnet tool restore
+    - name: Compute version with MinVer
+      run: |
+        CARTER_VERSION=$(dotnet minver --verbosity error)
+        echo "Computed version by MinVer: $CARTER_VERSION"
+        echo "MINVERVERSIONOVERRIDE=$CARTER_VERSION" >> GITHUB_ENV
     - name: Build Reason
       run: echo ${{github.ref}} and ${{github.event_name}}
     - name: Build with dotnet
-      run: find . -path ./template -prune -false -o -name '*.csproj' -execdir dotnet build --configuration Release --nologo {} \;
+      run: >-
+        dotnet build
+        --configuration Release
+        --nologo
     - name: Run tests
       run: >-
         dotnet test
@@ -41,7 +51,22 @@ jobs:
           path: '**/*.trx'
           reporter: dotnet-trx
 
-    # PR opened, push prelease Carter package to feedz
+    # PR opened, push prelease Carter and template package to feedz
+    - if: github.event_name == 'pull_request'
+      name: Replace project reference with NuGet package reference in template project
+      run: >-
+        ./replace-project-reference-with-package-reference.ps1
+        -ProjectFile ./template/content/CarterTemplate.csproj
+        -PackageVersion $env:MINVERVERSIONOVERRIDE
+      shell: pwsh
+
+    - if: github.event_name == 'pull_request'
+      name: Create Carter template NuGet package
+      run: >-
+        dotnet pack ./template/Template.csproj
+        --configuration Release
+        --nologo
+
     - if: github.event_name == 'pull_request'
       name: Push prerelease Carter package to Feedz
       run: ./push.sh carter feedz ${{ secrets.FEEDZ_KEY }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -29,6 +29,21 @@ jobs:
         CARTER_VERSION=$(dotnet minver --verbosity error)
         echo "Computed version by MinVer: $CARTER_VERSION"
         echo "MINVERVERSIONOVERRIDE=$CARTER_VERSION" >> $GITHUB_ENV
+    - name: Override MinVer version for pull requests
+      if: github.event_name == 'pull_request'
+      run: |
+        $minVerVersion = $env:MINVERVERSIONOVERRIDE
+
+        # From https://github.com/adamralph/minver/blob/dac9135c9085b364686cf318962741acdbf0f1af/MinVer/build/MinVer.targets#L54-L56
+        $major = $minVerVersion.Split('.')[0]
+        $minor = $minVerVersion.Split('.')[1]
+        $patch = $minVerVersion.Split('.')[2].Split('-')[0].Split('+')[0]
+
+        $pullRequestMinVerVersion = '{0}.{1}.{2}-pr.{3}.build.{4}' -f $major, $minor, $patch, '${{ github.event.number }}', $env:GITHUB_RUN_ID
+        Write-Output -Value ('Pull request MinVer version: {0}' -f $pullRequestMinVerVersion)
+
+        ('MINVERVERSIONOVERRIDE={0}' -f $pullRequestMinVerVersion) >> $env:GITHUB_ENV
+      shell: pwsh
     - name: Build Reason
       run: echo ${{github.ref}} and ${{github.event_name}}
     - name: Build with dotnet

--- a/push.sh
+++ b/push.sh
@@ -6,9 +6,10 @@ NUGET_TARGET_SERVICE=$2
 NUGET_API_KEY=$3
 
 if [ "$TARGET_PACKAGE" = "carter" ]; then
-  TARGET_PACKAGE_PATH="./src/Carter/**/*.nupkg"
+  # Publish both the Carter and the CarterTemplate packages
+  TARGET_PACKAGES="$(find -wholename "./src/Carter/**/*.nupkg" -or -wholename "./template/**/*.nupkg")"
 elif [ "$TARGET_PACKAGE" = "newtonsoft" ]; then
-  TARGET_PACKAGE_PATH="./src/Carter.ResponseNegotiators.Newtonsoft/**/*.nupkg"
+  TARGET_PACKAGES="$(find -wholename "./src/Carter.ResponseNegotiators.Newtonsoft/**/*.nupkg")"
 else
   echo "Unexpected target package name \"$TARGET_PACKAGE\"; Accepted values: carter, newtonsoft"
   exit 1
@@ -23,7 +24,7 @@ else
   exit 1
 fi
 
-for package in $(find -wholename "$TARGET_PACKAGE_PATH" | grep "test" -v); do
+for package in $(echo "$TARGET_PACKAGES" | grep "test" -v); do
   echo "${0##*/}": Pushing $package to $NUGET_TARGET_SERVICE \($NUGET_TARGET_URL\)...
   dotnet nuget push $package --source $NUGET_TARGET_URL --api-key $NUGET_API_KEY
 done

--- a/replace-project-reference-with-package-reference.ps1
+++ b/replace-project-reference-with-package-reference.ps1
@@ -1,0 +1,27 @@
+<#
+.SYNOPSIS
+    Replaces the Carter project reference by a NuGet package reference in a .csproj file
+.EXAMPLE
+    ./replace-project-reference-with-package-reference.ps1 -ProjectFile ./template/content/CarterTemplate.csproj -PackageVersion '7.0.0'
+#>
+[CmdletBinding()]
+param (
+    # The path to the .csproj file that needs to be updated
+    [Parameter(Mandatory = $true)]
+    [string]
+    $ProjectFile,
+
+    # The version of the Carter package to use in the package reference element
+    [Parameter(Mandatory = $true)]
+    [string]
+    $PackageVersion
+)
+
+if (-not (Test-Path -Path $ProjectFile)) {
+    throw ('The project file ''{0}'' does not exist' -f $ProjectFile)
+}
+
+$projectFileContents = Get-Content -Path $ProjectFile -Raw -Encoding utf8
+$newProjectFileContents = $projectFileContents -replace '<ProjectReference [\s\S]+?/>', ('<PackageReference Include="Carter" Version="{0}" />' -f $PackageVersion)
+
+Set-Content -Path $ProjectFile -Value $newProjectFileContents -Encoding utf8

--- a/template/Template.csproj
+++ b/template/Template.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <PackageType>Template</PackageType>
         <PackageVersion>6.1.1</PackageVersion>
         <PackageId>CarterTemplate</PackageId>

--- a/template/Template.csproj
+++ b/template/Template.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <PackageType>Template</PackageType>
-        <PackageVersion>6.1.1</PackageVersion>
         <PackageId>CarterTemplate</PackageId>
         <Description>A dotnet-new template for Carter applications.</Description>
         <Authors>Jonathan Channon</Authors>
@@ -15,6 +14,9 @@
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <ContentTargetFolders>content</ContentTargetFolders>
         <NoWarn>$(NoWarn);NU5128</NoWarn>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
     </PropertyGroup>
 
     <ItemGroup>
@@ -24,5 +26,11 @@
 
     <ItemGroup>
         <None Include="..\media\carterlogo.png" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="MinVer" Version="2.5.0">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 </Project>

--- a/template/content/.template.config/template.json
+++ b/template/content/.template.config/template.json
@@ -11,6 +11,7 @@
     "identity": "Carter.Template",
     "shortName": "carter",
     "tags": {
+        "type": "project",
         "language": "C#"
     },
     "sourceName": "CarterTemplate"

--- a/template/content/CarterTemplate.csproj
+++ b/template/content/CarterTemplate.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Carter" Version="6.1.1" />
+    <ProjectReference Include="..\..\src\Carter\Carter.csproj" />
   </ItemGroup>
 </Project>

--- a/template/content/CarterTemplate.csproj
+++ b/template/content/CarterTemplate.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>CarterTemplate</AssemblyName>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
Related to #298.
Discussed in https://github.com/CarterCommunity/Carter/pull/299#issuecomment-1257956828

## Goal

We want to publish the `CarterTemplate` NuGet package at the same time as the `Carter` package.
In other words, if we publish a new `Carter` package, let's say 7.1.2, we want to release a new `CarterTemplate` package with the same version.

The result can be seen in [this run](https://github.com/CarterCommunity/Carter/actions/runs/3260679089/jobs/5354416678) where we published the following packages to feedz:

- `Carter.6.1.2-pr.302.build.3260679089`, and
- `CarterTemplate.6.1.2-pr.302.build.3260679089`, which can create a project that depends on `Carter.6.1.2-pr.302.build.3260679089`

## Considerations

Today, the template project references the `Carter` NuGet package through a `<PackageReference>` element.
If we want to publish a new template package, we have to:

1. Publish a new Carter package
2. Update the package reference in the template project
3. Create the NuGet package and publish it

There are several downsides with this approach:

1. When we make changes to Carter, we don't know if they affect the template project since it's pinned to a specific version. It's only when we want to publish a new version of the template package that we discover potential issues due to API changes.
2. Updating the package reference, creating the package and publishing it is done manually.

This PR brings some changes to this:

- The template project now references the Carter project directly, so that if we make breaking API changes, they'll be picked up by the compiler. The result is that changes to the Carter code and the template code are made at the same time.
- Because we can't push a package with a project reference, we swap it for a package reference by using the version computed by MinVer
- We can then create the package and publish it, so we always have matching versions of Carter and the template packages.

## Detailed walkthrough

There's plenty of changes in this PR, here's my attempt at documenting them.

### MinVer version computed outside of MSBuild

We now compute the MinVer version outside of MSBuild with the MinVer CLI, see https://github.com/CarterCommunity/Carter/pull/302/files#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825R27-R31

We do this because of a chicken-and-egg problem: we need to know which version MinVer computes to inject the package reference in the template project before packing it, but as of now the version is only computed in MSBuild.

### Special MinVer version for PRs

I faced an issue where several different commits in my PR resulted in the same computed MinVer versions.
It's an expected behaviour as per https://github.com/adamralph/minver/issues/225.

To avoid this, we override the MinVer version with a unique prerelease tag that contains both the PR number and the GitHub Actions run id, see https://github.com/CarterCommunity/Carter/pull/302/files#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825R32-R46.

An example of this is `6.1.2-pr.302.build.562312354`.

### Explicitly packing the `Template` project

See https://github.com/CarterCommunity/Carter/pull/302/files#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825R83-R91

The `Template` project is not included in the VS solution, so a top-level `dotnet build` doesn't do anything with it.
I'm not sure whether it's intentional or not, happy to hear your thoughts.

### Using PowerShell

I'm more comfortable with PowerShell than with Bash, which is why I implemented the "swap project reference with package reference" and "override MinVer version" with PS.
I have no strong feeling about this, happy for it to be in Bash, but it might be quicker for someone who knows Bash to do it.

Did you make it all the way down here? If so, thanks 🙏