### PR TITLE
Stop publishing on PR build, start publishing on PR merge

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -6,6 +6,9 @@ on:
     # This will need to be changed to main
     - defaultinterface
   push:
+    branches:
+    # This will need to be changed to main
+    - defaultinterface
     tags:
     - '*'
 
@@ -41,8 +44,8 @@ jobs:
           path: '**/*.trx'
           reporter: dotnet-trx
 
-    # PR opened, push prelease Carter package to feedz
-    - if: github.event_name == 'pull_request'
+    # PR merged, push prelease Carter package to feedz
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads')
       name: Push prerelease Carter package to Feedz
       run: ./push.sh carter feedz ${{ secrets.FEEDZ_KEY }}
 


### PR DESCRIPTION
Follow-up to #300 as I misunderstood the desired logic.

This stops publishing prerelease `Carter` packages on PR builds, i.e. when they're open, and moves the logic to when they're merged, as discussed on [the Slack community workspace](https://cartercommunity.slack.com/archives/CA0M9TEUS/p1668789964001429?thread_ts=1668789401.978989&cid=CA0M9TEUS).

When merged, I'll react to those changed in #303 as there's some bits that will need to be updated.