### PR TITLE
Update workflow trigger to run on push to main branch

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,14 +1,15 @@
 name: .NET Core
 
 on:
+  # Run on all PRs
   pull_request:
-    branches:
-    # This will need to be changed to main
-    - defaultinterface
+
+  # Run when:
+  #  - The main branch is pushed to, i.e. a PR targeting main is merged
+  #  - The repo is tagged
   push:
     branches:
-    # This will need to be changed to main
-    - defaultinterface
+    - main
     tags:
     - '*'
 


### PR DESCRIPTION
Changes:

- Run the workflow on all PRs, no matter what branch they target, which ensures the solution builds and tests pass.
- Run the workflow when there's a push on the `main` branch, i.e. when a PR is merged &mdash; useful when #306 is merged, after which we'll probably stop working on the `defaultinterface` branch.

The side effect of this is that if we keep working on `defaultinterface` for a bit longer, new packages will **not** be pushed to Feedz every time we push or merge a PR.