### PR TITLE
Add possibility to specify policy names when requiring authorization at the module level

### DIFF
--- a/Carter.sln
+++ b/Carter.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2002
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33110.190
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carter", "src\Carter\Carter.csproj", "{A6D020CF-1722-4AB3-A8B3-69F54319AD6A}"
 EndProject
@@ -12,6 +12,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{35DE35A0-758D-4FDD-BDA3-67F04F65677D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{DCB5B9A0-F06D-4BDF-917D-A459C790C718}"
+	ProjectSection(SolutionItems) = preProject
+		test\Directory.Build.props = test\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carter.Tests", "test\Carter.Tests\Carter.Tests.csproj", "{32E3C950-F6C1-4635-B87F-0EA30044E2F4}"
 EndProject
@@ -19,15 +22,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "template", "template", "{47
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CarterTemplate", "template\content\CarterTemplate.csproj", "{572762BB-5DFF-425F-8F66-500B973DBB0E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Carter.Samples.Tests", "test\Carter.Samples.Tests\Carter.Samples.Tests.csproj", "{DD5E942A-D546-489B-A5E9-8CB42C61BEC1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carter.Samples.Tests", "test\Carter.Samples.Tests\Carter.Samples.Tests.csproj", "{DD5E942A-D546-489B-A5E9-8CB42C61BEC1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CarterAndMVC", "samples\CarterAndMVC\CarterAndMVC.csproj", "{CE26885C-BB25-4A2C-B550-1D807CD1A066}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CarterAndMVC", "samples\CarterAndMVC\CarterAndMVC.csproj", "{CE26885C-BB25-4A2C-B550-1D807CD1A066}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ValidatorOnlyProject", "samples\ValidatorOnlyProject\ValidatorOnlyProject.csproj", "{E5D99119-96EB-4C01-9EC2-A06FC3EEC182}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ValidatorOnlyProject", "samples\ValidatorOnlyProject\ValidatorOnlyProject.csproj", "{E5D99119-96EB-4C01-9EC2-A06FC3EEC182}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Carter.ResponseNegotiators.Newtonsoft", "src\Carter.ResponseNegotiators.Newtonsoft\Carter.ResponseNegotiators.Newtonsoft.csproj", "{D30E87B0-39AE-41FE-8BA3-E5F9FBFFDD64}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carter.ResponseNegotiators.Newtonsoft", "src\Carter.ResponseNegotiators.Newtonsoft\Carter.ResponseNegotiators.Newtonsoft.csproj", "{D30E87B0-39AE-41FE-8BA3-E5F9FBFFDD64}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Carter.ResponseNegotiators.Newtonsoft.Tests", "test\Carter.ResponseNegotiators.Newtonsoft.Tests\Carter.ResponseNegotiators.Newtonsoft.Tests.csproj", "{47DD3AA8-F072-41E3-AF7F-119DBBD8D14A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Carter.ResponseNegotiators.Newtonsoft.Tests", "test\Carter.ResponseNegotiators.Newtonsoft.Tests\Carter.ResponseNegotiators.Newtonsoft.Tests.csproj", "{47DD3AA8-F072-41E3-AF7F-119DBBD8D14A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Carter/CarterExtensions.cs
+++ b/src/Carter/CarterExtensions.cs
@@ -41,14 +41,7 @@ public static class CarterExtensions
 
                 if (carterModule.requiresAuthorization)
                 {
-                    if (carterModule.authorizationPolicyNames is null)
-                    {
-                        group = group.RequireAuthorization();
-                    }
-                    else
-                    {
-                        group = group.RequireAuthorization(carterModule.authorizationPolicyNames);
-                    }
+                    group = group.RequireAuthorization(carterModule.authorizationPolicyNames);
                 }
 
                 if (!string.IsNullOrWhiteSpace(carterModule.corsPolicyName))

--- a/src/Carter/CarterExtensions.cs
+++ b/src/Carter/CarterExtensions.cs
@@ -41,7 +41,14 @@ public static class CarterExtensions
 
                 if (carterModule.requiresAuthorization)
                 {
-                    group = group.RequireAuthorization();
+                    if (carterModule.authorizationPolicyNames is null)
+                    {
+                        group = group.RequireAuthorization();
+                    }
+                    else
+                    {
+                        group = group.RequireAuthorization(carterModule.authorizationPolicyNames);
+                    }
                 }
 
                 if (!string.IsNullOrWhiteSpace(carterModule.corsPolicyName))

--- a/src/Carter/ICarterModule.cs
+++ b/src/Carter/ICarterModule.cs
@@ -33,6 +33,8 @@ public abstract class CarterModule : ICarterModule
 
     internal bool requiresAuthorization;
 
+    internal string[] authorizationPolicyNames;
+
     internal string cacheOutputPolicyName;
 
     internal readonly string basePath = "/";
@@ -64,6 +66,19 @@ public abstract class CarterModule : ICarterModule
     public CarterModule RequireAuthorization()
     {
         this.requiresAuthorization = true;
+        this.authorizationPolicyNames = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Add authorization to all routes
+    /// </summary>
+    /// <param name="policyNames">A collection of policy names. If empty, the default authorization policy will be used.</param>
+    /// <returns></returns>
+    public CarterModule RequireAuthorization(params string[] policyNames)
+    {
+        this.requiresAuthorization = true;
+        this.authorizationPolicyNames = policyNames;
         return this;
     }
 

--- a/src/Carter/ICarterModule.cs
+++ b/src/Carter/ICarterModule.cs
@@ -33,7 +33,7 @@ public abstract class CarterModule : ICarterModule
 
     internal bool requiresAuthorization;
 
-    internal string[] authorizationPolicyNames;
+    internal string[] authorizationPolicyNames = Array.Empty<string>();
 
     internal string cacheOutputPolicyName;
 

--- a/src/Carter/ICarterModule.cs
+++ b/src/Carter/ICarterModule.cs
@@ -62,18 +62,10 @@ public abstract class CarterModule : ICarterModule
     /// <summary>
     /// Add authorization to all routes
     /// </summary>
-    /// <returns></returns>
-    public CarterModule RequireAuthorization()
-    {
-        this.requiresAuthorization = true;
-        this.authorizationPolicyNames = null;
-        return this;
-    }
-
-    /// <summary>
-    /// Add authorization to all routes
-    /// </summary>
-    /// <param name="policyNames">A collection of policy names. If empty, the default authorization policy will be used.</param>
+    /// <param name="policyNames">
+    /// A collection of policy names.
+    /// If <c>null</c> or empty, the default authorization policy will be used.
+    /// </param>
     /// <returns></returns>
     public CarterModule RequireAuthorization(params string[] policyNames)
     {

--- a/test/Carter.Tests/AuthorizationTestModule.cs
+++ b/test/Carter.Tests/AuthorizationTestModule.cs
@@ -24,14 +24,15 @@ public class DefaultAuthorizationTestModule : AuthorizationTestModuleBase
 }
 
 /// <summary>
-/// Test module that requires authorization specified by the <see cref="SpecificPolicyAuthorizationTestModule.SpecificPolicy"/> policy for all the added routes.
+/// Test module that requires authorization specified by the <see cref="SpecificPolicyOne"/> and <see cref="SpecificPolicyTwo"/> policies for all the added routes.
 /// </summary>
 public class SpecificPolicyAuthorizationTestModule : AuthorizationTestModuleBase
 {
-    public const string SpecificPolicy = nameof(SpecificPolicy);
+    public const string SpecificPolicyOne = nameof(SpecificPolicyOne);
+    public const string SpecificPolicyTwo = nameof(SpecificPolicyTwo);
 
     public SpecificPolicyAuthorizationTestModule()
     {
-        RequireAuthorization(SpecificPolicy);
+        RequireAuthorization(SpecificPolicyOne, SpecificPolicyTwo);
     }
 }

--- a/test/Carter.Tests/AuthorizationTestModule.cs
+++ b/test/Carter.Tests/AuthorizationTestModule.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Carter.Tests;
+
+public abstract class AuthorizationTestModuleBase : CarterModule
+{
+    public override void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/authorizedendpoint", async (HttpContext context) => await context.Response.WriteAsync("Authorized endpoint"));
+    }
+}
+
+/// <summary>
+/// Test module that requires default authorization for all the added routes.
+/// </summary>
+public class DefaultAuthorizationTestModule : AuthorizationTestModuleBase
+{
+    public DefaultAuthorizationTestModule()
+    {
+        RequireAuthorization();
+    }
+}
+
+/// <summary>
+/// Test module that requires authorization specified by the <see cref="SpecificPolicyAuthorizationTestModule.SpecificPolicy"/> policy for all the added routes.
+/// </summary>
+public class SpecificPolicyAuthorizationTestModule : AuthorizationTestModuleBase
+{
+    public const string SpecificPolicy = nameof(SpecificPolicy);
+
+    public SpecificPolicyAuthorizationTestModule()
+    {
+        RequireAuthorization(SpecificPolicy);
+    }
+}

--- a/test/Carter.Tests/AuthorizationTests.cs
+++ b/test/Carter.Tests/AuthorizationTests.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Carter.Tests;
+
+public class AuthorizationTests : IDisposable
+{
+    private readonly ITestOutputHelper outputHelper;
+
+    private TestServer server;
+
+    private HttpClient httpClient;
+
+    private bool defaultPolicyEvaluated;
+
+    private bool specificPolicyEvaluated;
+
+    public AuthorizationTests(ITestOutputHelper outputHelper) =>
+        this.outputHelper = outputHelper;
+
+    [Fact]
+    public async Task Should_evaluate_default_policy_when_no_specific_policy_is_specified()
+    {
+        // Arrange
+        BuildTestServer<DefaultAuthorizationTestModule>();
+
+        // Act
+        _ = await this.httpClient.GetAsync("/authorizedendpoint");
+
+        // Assert
+        Assert.True(defaultPolicyEvaluated);
+        Assert.False(specificPolicyEvaluated);
+    }
+
+    [Fact]
+    public async Task Should_evaluate_specific_policy_when_it_is_specified()
+    {
+        // Arrange
+        BuildTestServer<SpecificPolicyAuthorizationTestModule>();
+
+        // Act
+        _ = await this.httpClient.GetAsync("/authorizedendpoint");
+
+        // Assert
+        Assert.True(specificPolicyEvaluated);
+        Assert.False(defaultPolicyEvaluated);
+    }
+
+    /// <summary>
+    /// Builds a test server with the module specified by the <typeparamref name="TModule"/> type parameter.
+    /// </summary>
+    /// <typeparam name="TModule">The type of Carter module to register.</typeparam>
+    private void BuildTestServer<TModule>()
+        where TModule : AuthorizationTestModuleBase
+    {
+        this.server = new TestServer(
+            new WebHostBuilder()
+                .ConfigureServices(x =>
+                {
+                    x.AddLogging(b =>
+                    {
+                        XUnitLoggerExtensions.AddXUnit((ILoggingBuilder)b, outputHelper, x => x.IncludeScopes = true);
+                        b.SetMinimumLevel(LogLevel.Debug);
+                    });
+
+                    x.AddAuthentication().AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>("TestScheme", options => { });
+                    x.AddAuthorization(configure: c =>
+                    {
+                        c.DefaultPolicy = new AuthorizationPolicyBuilder("TestScheme")
+                            .RequireAssertion(handler: c =>
+                            {
+                                this.defaultPolicyEvaluated = true;
+                                return true;
+                            })
+                            .Build();
+
+                        c.AddPolicy(SpecificPolicyAuthorizationTestModule.SpecificPolicy, new AuthorizationPolicyBuilder("TestScheme")
+                            .RequireAssertion(handler: c =>
+                            {
+                                this.specificPolicyEvaluated = true;
+                                return true;
+                            })
+                            .Build());
+                    });
+
+                    x.AddRouting();
+                    x.AddCarter(configurator: c =>
+                    {
+                        c.WithModule<TModule>();
+                    });
+                })
+                .Configure(x =>
+                {
+                    x.UseRouting();
+                    x.UseAuthentication();
+                    x.UseAuthorization();
+                    x.UseEndpoints(builder => builder.MapCarter());
+                })
+            );
+
+        this.httpClient = this.server.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        this.httpClient?.Dispose();
+        this.server?.Dispose();
+    }
+
+    /// <summary>
+    /// See https://learn.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-7.0#mock-authentication
+    /// </summary>
+    private class TestAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public TestAuthenticationHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder,
+            ISystemClock clock)
+            : base(options, logger, encoder, clock)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var claims = new[] { new Claim(ClaimTypes.Name, "Test user") };
+            var identity = new ClaimsIdentity(claims, "Test");
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, "TestScheme");
+
+            var result = AuthenticateResult.Success(ticket);
+
+            return Task.FromResult(result);
+        }
+    }
+}
+
+

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -8,9 +8,9 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+        <PackageReference Include="xunit" Version="2.4.2" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Motivation

It was found by a member of the Carter community Slack that the current `RequireAuthorization` method on `CarterModule` doesn't allow to specify one or more policy names.
The result is that the only policy that is appliable at the module level is the default authorization policy configured in the app.

### Changes

This PR adds another overload of the `RequireAuthorization` that allows passing one or more policy names.

It's worth noting that ASP.NET Core has even more overloads, see https://source.dot.net/#q=requireauthorization%3CTBuilder%3E:

- `RequireAuthorization<TBuilder>(this TBuilder builder, AuthorizationPolicy policy)`
- `RequireAuthorization<TBuilder>(this TBuilder builder, Action<AuthorizationPolicyBuilder> configurePolicy)`
- `RequireAuthorization<TBuilder>(this TBuilder builder, params IAuthorizeData[] authorizeData)`

Do we want to implement some of those?

### Tests

Writing tests for this involved quite a bit of plumbing code.
If you'd rather not have tests, or if you feel there's an easier way to test this than building a server and firing a request, please let me know.