### PR TITLE
Update README.md after following the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,11 @@ You can get started using either the template or by adding the package manually 
 
 1. Install the template - `dotnet new -i CarterTemplate`
 
-2. Optional: This template creates the files directly in the current directory, so you might want to create a directory for the new application - `mkdir MyCarterApp`
+2. Create a new application using template - `dotnet new carter -n MyCarterApp -o MyCarterApp`
 
-3. Optional: Go into the directory - `cd MyCarterApp`
+3. Go into the new directory created for the application `cd MyCarterApp`
 
-4. Create a new application using template - `dotnet new carter -n MyCarterApp`
-
-5. Run the application - `dotnet run`
+4. Run the application - `dotnet run`
 
 #### Package
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ You can get started using either the template or by adding the package manually 
 
 1. Install the template - `dotnet new -i CarterTemplate`
 
-2. Create a new application using template - `dotnet new Carter -n MyCarterApp`
+2. Optional: This template creates the files directly in the current directory, so you might want to create a directory for the new application - `mkdir MyCarterApp`
 
-3. Run the application - `dotnet run`
+3. Optional: Go into the directory - `cd MyCarterApp`
+
+4. Create a new application using template - `dotnet new carter -n MyCarterApp`
+
+5. Run the application - `dotnet run`
 
 #### Package
 


### PR DESCRIPTION
On SDK 7.0.100 and tried to follow the instructions in the README.md

When installing the template per step 1.

1. Install the template - `dotnet new -i CarterTemplate`

This is purely FYI, I am not changing anything to address the warning I got:

 ❯  dotnet new -i CarterTemplate
Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead. For more information, run:
   dotnet new install -h

The following template packages will be installed:
   CarterTemplate

Success: CarterTemplate::7.0.0 installed the following templates:
Template Name    Short Name  Language  Tags
---------------  ----------  --------  ------------------------------
Carter Template  carter      [C#]      Carter/Carter Template/NancyFX

For step 2:

2. Create a new application using template - `dotnet new Carter -n MyCarterApp`

I got this error:

 ❯  dotnet new Carter -n MyCarterApp
No templates or subcommands found matching: 'Carter'. Did you mean one of the following templates?
   dotnet new carter

To list installed templates similar to 'Carter', run:
   dotnet new list Carter
To search for the templates on NuGet.org, run:
   dotnet new search Carter

For details on the exit code, refer to https://aka.ms/templating-exit-codes#103

I then did as suggested and ran:

 ❯  dotnet new carter -n MyCarterApp

which created files directly in the current directory, so I added a step to create a new folder and go into that. I would suggest creating a new .sln file considering you use the phrase "application" several times, but I can see how that might be problematic for people wanting to try Carter on existing projects.