### PR TITLE
Changing the scope of Validators to Scoped.

### DIFF
--- a/src/Carter/CarterConfigurator.cs
+++ b/src/Carter/CarterConfigurator.cs
@@ -162,5 +162,4 @@ public class CarterConfigurator
         this.ValidatorServiceLifetime = serviceLifetime;
         return this;
     }
-
 }

--- a/src/Carter/CarterConfigurator.cs
+++ b/src/Carter/CarterConfigurator.cs
@@ -3,6 +3,7 @@ namespace Carter;
 using System;
 using System.Collections.Generic;
 using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
@@ -15,6 +16,7 @@ public class CarterConfigurator
         this.ModuleTypes = new List<Type>();
         this.ValidatorTypes = new List<Type>();
         this.ResponseNegotiatorTypes = new List<Type>();
+        this.ValidatorServiceLifetime = ServiceLifetime.Singleton;
     }
 
     internal bool ExcludeValidators;
@@ -22,6 +24,8 @@ public class CarterConfigurator
     internal bool ExcludeModules;
         
     internal bool ExcludeResponseNegotiators;
+
+    internal ServiceLifetime ValidatorServiceLifetime;
 
     internal List<Type> ModuleTypes { get; }
 
@@ -147,4 +151,16 @@ public class CarterConfigurator
         this.ExcludeResponseNegotiators = true;
         return this;
     }
+
+    /// <summary>
+    /// Define the lifetime of the validator
+    /// Default: Singleton
+    /// </summary>
+    /// <returns></returns>
+    public CarterConfigurator WithValidatorLifetime(ServiceLifetime serviceLifetime)
+    {
+        this.ValidatorServiceLifetime = serviceLifetime;
+        return this;
+    }
+
 }

--- a/src/Carter/CarterExtensions.cs
+++ b/src/Carter/CarterExtensions.cs
@@ -176,11 +176,11 @@ public static class CarterExtensions
 
         foreach (var validator in validators)
         {
-            services.AddSingleton(typeof(IValidator), validator);
-            services.AddSingleton(validator);
+            services.AddScoped(typeof(IValidator), validator);
+            services.AddScoped(validator);
         }
 
-        services.AddSingleton<IValidatorLocator, DefaultValidatorLocator>();
+        services.AddScoped<IValidatorLocator, DefaultValidatorLocator>();
 
         foreach (var newModule in newModules)
         {


### PR DESCRIPTION
The change is necessary to allow Validators that use external access, such as database queries, to be possible. In this case, I was using an NHibernate Session configured as Scoped. Still, I received an exception stating that my Validator is registered as Singleton, trying to access a service configured as scoped.
According to FluentValidation documentation, the default record is as Scoped (https://docs.fluentvalidation.net/en/latest/di.html)
I made the adjustments and did some tests, and everything worked usually.