### PR TITLE
Update target framework to dotnet 8

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 7.*
+        dotnet-version: 8.*
     - name: Build Reason
       run: echo ${{github.ref}} and ${{github.event_name}}
     - name: Build with dotnet

--- a/samples/CarterAndMVC/CarterAndMVC.csproj
+++ b/samples/CarterAndMVC/CarterAndMVC.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>CarterAndMVC</AssemblyName>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>

--- a/samples/CarterSample/CarterSample.csproj
+++ b/samples/CarterSample/CarterSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/ValidatorOnlyProject/ValidatorOnlyProject.csproj
+++ b/samples/ValidatorOnlyProject/ValidatorOnlyProject.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.3.0" />
+    <PackageReference Include="FluentValidation" Version="11.8.0" />
   </ItemGroup>
 </Project>

--- a/samples/ValidatorOnlyProject/ValidatorOnlyProject.csproj
+++ b/samples/ValidatorOnlyProject/ValidatorOnlyProject.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="10.3.0" />

--- a/src/Carter.ResponseNegotiators.Newtonsoft/Carter.ResponseNegotiators.Newtonsoft.csproj
+++ b/src/Carter.ResponseNegotiators.Newtonsoft/Carter.ResponseNegotiators.Newtonsoft.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Authors>Jonathan Channon</Authors>
         <Description>Carter is framework that is a thin layer of extension methods and functionality over ASP.NET Core allowing code to be more explicit and most importantly more enjoyable.</Description>
         <PackageTags>asp.net core;nancy;.net core;routing;carter</PackageTags>
@@ -20,7 +20,7 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Carter" Version="7.1.0" />
+        <PackageReference Include="Carter" Version="7.2.0" />
         <PackageReference Include="MinVer" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Carter/Carter.csproj
+++ b/src/Carter/Carter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Authors>Jonathan Channon</Authors>
         <Description>Carter is framework that is a thin layer of extension methods and functionality over ASP.NET Core allowing code to be more explicit and most importantly more enjoyable.</Description>
         <PackageTags>asp.net core;nancy;.net core;routing;carter</PackageTags>
@@ -20,8 +20,8 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="FluentValidation" Version="11.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+        <PackageReference Include="FluentValidation" Version="11.8.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
         <PackageReference Include="MinVer" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>

--- a/template/Template.csproj
+++ b/template/Template.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <PackageType>Template</PackageType>
         <PackageId>CarterTemplate</PackageId>
         <Description>A dotnet-new template for Carter applications.</Description>

--- a/template/content/CarterTemplate.csproj
+++ b/template/content/CarterTemplate.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>CarterTemplate</AssemblyName>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/test/Carter.Tests/AuthorizationTests.cs
+++ b/test/Carter.Tests/AuthorizationTests.cs
@@ -112,7 +112,7 @@ public class AuthorizationTests : IDisposable
     }
 
     /// <summary>
-    /// See https://learn.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-7.0#mock-authentication
+    /// See https://learn.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-8.0#mock-authentication
     /// </summary>
     private class TestAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
     {
@@ -138,5 +138,3 @@ public class AuthorizationTests : IDisposable
         }
     }
 }
-
-

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -8,7 +8,7 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
         <PackageReference Include="xunit" Version="2.4.2" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>


### PR DESCRIPTION
As far as I can tell there are no breaking changes to upgrade to dotnet 8. The only issue I saw was a new deprecation warning in the mock authentication test.  I checked out the referenced URL for dotnet 8 and the code sample they provide is still using the same signature.  All of the tests are still passing.

Also, it looks like the Carter.ResponseNegotiators.Newtonsoft project references the NuGet package and not the project, so I can't update that without your assistance.  If you publish a pre-release Carter package I can update the reference and run the unit tests against the pre-release version.

Additionally, I updated the FluentValidator reference to the latest version in all projects. 

Let me know if there's anything else I can do.