### PR TITLE
Actualiza Carter.Analyzers.csproj y versión de paquete

### DIFF
--- a/src/Carter.Analyzers/Carter.Analyzers.csproj
+++ b/src/Carter.Analyzers/Carter.Analyzers.csproj
@@ -22,18 +22,18 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <None Include="..\..\media\carterlogo.png" Pack="true" PackagePath="\"/>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\media\carterlogo.png" Pack="true" PackagePath="\" />
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
         <PackageReference Include="MinVer" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Carter.Tests"/>
+        <InternalsVisibleTo Include="Carter.Tests" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
- Ajustados elementos `<None Include>` y `<InternalsVisibleTo>` para agregar un espacio antes del cierre `/>`.
- Actualizada la versión del paquete `Microsoft.CodeAnalysis.CSharp` de `4.7.0` a `4.11.0`.